### PR TITLE
faucet fix

### DIFF
--- a/clients/contracts/token.ts
+++ b/clients/contracts/token.ts
@@ -31,17 +31,14 @@ export class TokenContract extends DelphinusContract {
 
   mint(amount: number) {
     const pbinder = new PromiseBinder();
+
     return pbinder.return(async () => {
-      return await pbinder.bind(
-        "Mint",
-        this._mint(amount)
-      );
+      await pbinder.bind("Mint", console.log("Minting"));
+      return await pbinder.bind("Transfer", this._mint(amount));
     });
   }
 
   transfer(address: string, amount: number) {
-    return this.getWeb3Contract()
-      .methods.transfer(address, amount)
-      .send();
+    return this.getWeb3Contract().methods.transfer(address, amount).send();
   }
 }

--- a/clients/contracts/token.ts
+++ b/clients/contracts/token.ts
@@ -33,8 +33,8 @@ export class TokenContract extends DelphinusContract {
     const pbinder = new PromiseBinder();
 
     return pbinder.return(async () => {
-      await pbinder.bind("Mint", console.log("Minting"));
-      return await pbinder.bind("Transfer", this._mint(amount));
+      await new Promise((f) => setTimeout(f, 1000));
+      return await pbinder.bind("Mint", this._mint(amount));
     });
   }
 


### PR DESCRIPTION
Added in a dummy bind for pbinder as there is a bug within pbinder that binds the event before they are added to list so they get lost and don't get tracked. 
This is just a workaround since there looks like a potential issue with pbinder itself (there is a comment in pbinder from web3subscriber repo that says FIXME and looks to be about the same issue)