### PR TITLE
move pinder out of mint

### DIFF
--- a/clients/contracts/token.ts
+++ b/clients/contracts/token.ts
@@ -25,18 +25,8 @@ export class TokenContract extends DelphinusContract {
     return this.getWeb3Contract().methods.balanceOf(account).call();
   }
 
-  private _mint(amount: number) {
-    return this.getWeb3Contract().methods.mint(amount).send();
-  }
-
   mint(amount: number) {
-    const pbinder = new PromiseBinder();
-    return pbinder.return(async () => {
-      return await pbinder.bind(
-        "Mint",
-        this._mint(amount)
-      );
-    });
+    return this.getWeb3Contract().methods.mint(amount).send();
   }
 
   transfer(address: string, amount: number) {

--- a/clients/tools/token/mint.ts
+++ b/clients/tools/token/mint.ts
@@ -12,6 +12,7 @@ async function main(configName: string, targetAccount: string) {
       let token = l1client.getTokenContract();
       // await web3.eth.net.getId();
       try {
+        pbinder.snapshot("Mint");
         console.log("mint token:", token.address());
         let balance = await token.balanceOf(account);
         console.log("sender: balance before mint:", balance);


### PR DESCRIPTION
Move pbinder out of mint since it is only contains single web3 transaction. Instead we will add pbinder into ts-sdk for mint in l1tx.